### PR TITLE
Fix VecraftClient.close

### DIFF
--- a/vecraft_db/client/vecraft_client.py
+++ b/vecraft_db/client/vecraft_client.py
@@ -260,4 +260,5 @@ class VecraftClient:
 
     def close(self):
         """Graceful shutdown Vecraft db"""
-        self.planner.plan_shutdown()
+        plan = self.planner.plan_shutdown()
+        self.executor.execute(plan)


### PR DESCRIPTION
## Summary
- ensure shutdown plan is executed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683f4f78caf883308e38ba148f288a92