### PR TITLE
Fix create_collection to include vector_type

### DIFF
--- a/vecraft_rest_client/tests/test_vecraft_rest_api_client.py
+++ b/vecraft_rest_client/tests/test_vecraft_rest_api_client.py
@@ -108,7 +108,7 @@ class TestVecraftFastAPIClient(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, expected)
         self.client.session.post.assert_called_once_with(
             f"https://testserver/collections/{self.test_collection}/create",
-            json=CreateCollectionRequest(dim=5, vector_type="float32", checksum_algorithm="sha256").dict()
+            json=CreateCollectionRequest(dim=5, vector_type="float", checksum_algorithm="sha256").dict(),
         )
 
     async def test_list_collections(self):

--- a/vecraft_rest_client/vecraft_rest_api_client.py
+++ b/vecraft_rest_client/vecraft_rest_api_client.py
@@ -45,6 +45,7 @@ class VecraftFastAPIClient:
         assert self.session, "Client session not initialized. Use 'async with' context."
         payload = CreateCollectionRequest(
             dim=collection_schema.dim,
+            vector_type=collection_schema.vector_type,
             checksum_algorithm=collection_schema.checksum_algorithm
         ).dict()
         response = await self.session.post(


### PR DESCRIPTION
## Summary
- include vector_type in CreateCollectionRequest in `VecraftFastAPIClient`
- adapt unit tests for new parameter

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683f5119b74c8330a8d8d15092697b02